### PR TITLE
Add OrcaLayer to Wallet & Trader Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ If this list saves you some digging, a ⭐ on the repo helps more people find it
   - **Pricing:** free profiles, additional Pro analytics.
   - **Phase:** live.
   - **Added:** Aug 2026 · **Reviewed:** Aug 2026
+ 
+- **[OrcaLayer](https://orcalayer.com/)**: Polymarket analytics covering wallet lookup, smart-money leaderboards, whale alerts, and market research, built on its own index of on-chain fills from the Polygon CTF contracts.
+  Farmer filter removes airdrop-farmed wallets from rankings, NegRisk correction fixes win rates on multi-outcome markets, plus side-level FIFO PnL, median hold time, category hubs, trader comparison, an ISW-based territory monitor for Ukraine markets, a Telegram signal channel, and a REST API.
+  - **Best for:** telling whether a headline 90%+ win rate is real conviction or volume farmed at 95 cents and above.
+  - **Team:** solo developer. Scoring methodology and weights published on the site.
+  - **Pricing:** free tier, paid plans for API access and alerts.
+  - **Phase:** live.
+  - **Added:** Aug 2026 · **Reviewed:** Aug 2026
 
 [↑ Back to top](#top)
 


### PR DESCRIPTION
Adding OrcaLayer to Wallet & Trader Analytics.

What it is: Polymarket analytics built on its own index of on-chain fills from the Polygon CTF contracts rather than on the public API alone. Wallet lookup, smart-money leaderboards, whale alerts, market and category research, trader comparison, and a REST API.

Two things that separate it from the other entries in that section:

- Farmer filter. Wallets whose average entry price sits above 95 cents get flagged and dropped from rankings, so a 99% win rate farmed on almost-settled markets does not read as skill.
- NegRisk correction. Multi-outcome markets settle several tokens at once and naive win-rate maths gets them wrong. Rates are corrected for it.

Also side-level FIFO PnL, median hold time, category hubs, an ISW-based territory monitor for the Ukraine markets, a Telegram signal channel, and a free airdrop-readiness checker at /airdrop.

Scoring methodology and weights are published at orcalayer.com/methodology, so anything in the rankings can be checked against the formula.

Solo developer, no affiliation with Polymarket. Free tier, paid plans for API access and alerts. Happy to trim or reword the entry if the format is off.

Came here from the r/PredictionsMarkets thread, thanks for the pointer.