### PR TITLE
Add Live Tennis API to Research & Market Discovery (tennis resolution / ground-truth data feed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ If this list saves you some digging, a ⭐ on the repo helps more people find it
   - **Phase:** live.
   - **Added:** Aug 2026 · **Reviewed:** Aug 2026
 
+- **[Live Tennis API](https://livetennisapi.com)**: Real-time REST and WebSocket API streaming live tennis match state as structured JSON — score, sets/games/points, who's serving, a three-valued break-point flag, and retirement / walkover / completed status.
+  The same kind of ground-truth result data used to resolve tennis contracts on Polymarket and Kalshi (a match completing, a retirement, or a walkover is the resolution event). Covers ATP, WTA, and ITF down to the lower tours. An MIT-licensed, observe-only [match↔market matching toolkit](https://github.com/livetennisapi/polymarket-tennis) pairs the feed against Gamma tennis markets, and there's an [MCP server](https://www.npmjs.com/package/livetennisapi-mcp) on the official MCP Registry for agent research.
+  - **Best for:** checking the real resolution data behind tennis markets instead of scraping a scoreboard.
+  - **Team:** independent; operated by the Live Tennis API team (livetennisapi.com).
+  - **Pricing:** free tier (live scores, match state, players, fixtures; 30 req/min, 100/day, no card); paid plans above that.
+  - **Phase:** live.
+  - **Added:** Aug 2026 · **Reviewed:** Aug 2026
+
 - **[TickFoundry](https://tickfoundry.com/)**: Archived Polymarket order-book data pulled straight off the live socket, not periodic snapshots.
   Every book update, full L1 and 25-level L2 depth on both sides, and trade data continuous since May 11, 2026. Live reference-price feeds and Polymarket's own sports state feed came online June 21, 2026, and a separate onchain fill layer reaches back further and carries wallet identity the socket data never had. One thing worth knowing: the feeds carry no `condition_id`, so joining scores to books is done by time, not by ID.
   - **Best for:** rebuilding exactly what the order book looked like at any past moment.


### PR DESCRIPTION
**Disclosure:** I run the Live Tennis API — judge it on the merits and drop it if it doesn't fit.

### What this adds
This adds **Live Tennis API** to the **🧠 Research & Market Discovery** section, right after the **METAR.ws** entry. METAR.ws is listed there as the weather data feed "used to resolve weather-related contracts on Polymarket and Kalshi." Live Tennis API is the direct tennis analog: a live-tennis match-state / result feed — the ground truth a tennis event market resolves against (a match completing, a retirement, or a walkover *is* the resolution event).

It is purely a **data source**, not a trading venue or execution tool — no orders, no wallet connection. It streams structured JSON match state (score, sets/games/points, who's serving, a three-valued break-point flag, and retirement / walkover / completed status) over REST + WebSocket, covering ATP, WTA, and ITF.

### Why it fits this section
The Research & Market Discovery section already catalogs pure data feeds used for resolution and research (METAR.ws for weather, TickFoundry and PolyOrderbooks for order-book history). A tennis result feed fills the obvious gap for the sports side.

### Inclusion basis
- **Live and free to try:** free tier (live scores, match state, players, fixtures) at 30 req/min, 100/day, no card — so it survives the monthly dead-link/abandoned review.
- **Real docs and endpoints:** base `https://api.livetennisapi.com/api/public/v1`, `X-API-Key` header, `{data:[...]}` envelope.
- **Format-matched:** the entry below follows the exact bullet structure (bold link + colon lead line, detail line, then Best for / Team / Pricing / Phase / Added·Reviewed).

### Entry added
```
- **[Live Tennis API](https://livetennisapi.com)**: Real-time REST and WebSocket API streaming live tennis match state as structured JSON — score, sets/games/points, who's serving, a three-valued break-point flag, and retirement / walkover / completed status.
  The same kind of ground-truth result data used to resolve tennis contracts on Polymarket and Kalshi (a match completing, a retirement, or a walkover is the resolution event). Covers ATP, WTA, and ITF down to the lower tours. An MIT-licensed, observe-only [match↔market matching toolkit](https://github.com/livetennisapi/polymarket-tennis) pairs the feed against Gamma tennis markets, and there's an [MCP server](https://www.npmjs.com/package/livetennisapi-mcp) on the official MCP Registry for agent research.
  - **Best for:** checking the real resolution data behind tennis markets instead of scraping a scoreboard.
  - **Team:** independent; operated by the Live Tennis API team (livetennisapi.com).
  - **Pricing:** free tier (live scores, match state, players, fixtures; 30 req/min, 100/day, no card); paid plans above that.
  - **Phase:** live.
  - **Added:** Aug 2026 · **Reviewed:** Aug 2026
```

Happy to adjust wording, trim, or move it — your call as maintainer.